### PR TITLE
Fix broken BoolParser and activate its tests

### DIFF
--- a/bool.go
+++ b/bool.go
@@ -10,7 +10,7 @@ import (
 type Bool bool
 
 // BoolParser 解析 bool
-var BoolParser = p.Choice(p.Str("true"), p.Str("false")).Bind(func(input interface{}) p.P {
+var BoolParser = p.Choice(p.Try(p.Str("true")), p.Str("false")).Bind(func(input interface{}) p.P {
 	return func(st p.State) (interface{}, error) {
 		switch input.(string) {
 		case "true":

--- a/bool_test.go
+++ b/bool_test.go
@@ -6,7 +6,7 @@ import (
 	p "github.com/Dwarfartisan/goparsec2"
 )
 
-func TestingBoolParse0(t *testing.T) {
+func TestBoolParse0(t *testing.T) {
 	data := "true"
 	st := p.BasicStateFromText(data)
 	o, err := BoolParser(&st)
@@ -22,16 +22,16 @@ func TestingBoolParse0(t *testing.T) {
 	}
 }
 
-func TestingBoolParse1(t *testing.T) {
+func TestBoolParse1(t *testing.T) {
 	data := "false"
 	st := p.BasicStateFromText(data)
 	o, err := BoolParser(&st)
 	if err != nil {
 		t.Fatalf("expect bool but error %v", err)
 	}
-	if b, ok := o.(bool); ok {
-		if !b {
-			t.Fatalf("expect bool true but %v", b)
+	if b, ok := o.(Bool); ok {
+		if b {
+			t.Fatalf("expect bool false but %v", b)
 		}
 	} else {
 		t.Fatalf("excpet bool but %v", o)


### PR DESCRIPTION
- First candidate in BoolParser can't rollback. Thus when it fails,
  second candidate gets no chance to try. Wrapping it with a Try solves
  this.
- Tests for BoolParser are not activated due to wrong naming.

Signed-off-by: Kezhu Wang kezhuw@gmail.com
